### PR TITLE
Ogle iii data initial integration

### DIFF
--- a/justice/mmap_array.py
+++ b/justice/mmap_array.py
@@ -7,16 +7,20 @@ from __future__ import print_function
 import json
 import os
 import os.path
+import pickle
 
 import numpy as np
+import pandas as pd
 
 default_array_dir = os.path.abspath(
-    os.path.join(os.path.abspath(__file__), "../../data/mmap_arrays"))
+    os.path.join(os.path.abspath(__file__), "../../data/mmap_arrays")
+)
 
 
 class MmapArrayFile(object):
-    def __init__(self, name, array_dir=default_array_dir, create_parent_dir=True,
-                 order='C'):
+    def __init__(
+        self, name, array_dir=default_array_dir, create_parent_dir=True, order='C'
+    ):
         if order not in {'C', 'F'}:
             raise ValueError("order parameter must be 'C' or 'F'. See numpy docs.")
         self.array_dir = array_dir
@@ -44,8 +48,13 @@ class MmapArrayFile(object):
         if not isinstance(array, np.ndarray):
             raise TypeError("Expected an ndarray")
 
-        np.memmap(self.mmap_filename, dtype=array.dtype, mode='w+', shape=array.shape,
-                  order=self.order)[:] = array
+        np.memmap(
+            self.mmap_filename,
+            dtype=array.dtype,
+            mode='w+',
+            shape=array.shape,
+            order=self.order
+        )[:] = array
         try:
             with open(self.info_file, 'w') as f:
                 json.dump({'shape': array.shape, 'dtype': array.dtype.name}, f)
@@ -59,3 +68,53 @@ class MmapArrayFile(object):
             shape_dtype['shape'] = tuple(shape_dtype['shape'])
             shape_dtype['dtype'] = getattr(np, shape_dtype['dtype'])
         return np.memmap(self.mmap_filename, mode='r', order=self.order, **shape_dtype)
+
+
+class IndexedArray(object):
+    def __init__(self, index_df, lc_data):
+        self.index_df = index_df
+        self.lc_data = lc_data
+
+    def get_data(self, row):
+        return self.lc_data[row.start:row.end, :]
+
+
+class IndexedArrayDescriptor(object):
+    def __init__(self, base_dir, index_name="index_df.pickle", array_name="all"):
+        self.index_filename = os.path.join(base_dir, index_name)
+        self.all_lc_data = MmapArrayFile(array_name, array_dir=base_dir, order='C')
+
+    def read(self):
+        with open(self.index_filename, 'rb') as f:
+            index_df = pickle.load(f)
+        return IndexedArray(index_df=index_df, lc_data=self.all_lc_data.read())
+
+    def write(self, index_rows, data):
+        """Writes parsed data.
+
+        :param index_rows:
+        :param data:
+        """
+        if len(index_rows) != len(data):
+            raise ValueError("Number of index rows must match number of data elements")
+
+        # Accumulate list of starting indices. This will yield (n + 1) values.
+        start_indices = [0]
+        for sub_array in data:
+            start_indices.append(start_indices[-1] + len(sub_array))
+            if sub_array:
+                assert len(sub_array[0]) == 3, "Expected tuples of (time, flux, err)"
+
+        # Write index data frame with start and end indices.
+        index_df = pd.DataFrame.from_records(index_rows)
+        index_df['start'] = np.array(start_indices[:-1], dtype=np.int64)
+        index_df['end'] = np.array(start_indices[1:], dtype=np.int64)
+        with open(self.index_filename, 'wb') as f:
+            pickle.dump(index_df, f, protocol=2)
+
+        # Write all of the data.
+        all_values = np.array([
+            time_flux_err_tuple for sub_array in data for time_flux_err_tuple in sub_array
+        ],
+            dtype=np.float64)
+        self.all_lc_data.write(all_values)

--- a/justice/ogle_data.py
+++ b/justice/ogle_data.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""Defines OGLE datasets."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os.path
+
+from justice import mmap_array
+
+ogle_dir = os.path.join(mmap_array.default_array_dir, 'ogle_iii')
+
+
+def for_subset(name):
+    return mmap_array.IndexedArrayDescriptor(base_dir=os.path.join(ogle_dir, name))

--- a/justice/ogle_data_builder.py
+++ b/justice/ogle_data_builder.py
@@ -60,6 +60,8 @@ def build(ogle3_data_dir, ia_descriptor, expected_bands=('I', 'V')):
             data.append(contents)
 
     ia_descriptor.write(index_rows, data)
+    print("Wrote dataset in {} with {} light curves".format(
+        ia_descriptor.index_filename, len(data)))
 
 
 def main():

--- a/justice/ogle_data_builder.py
+++ b/justice/ogle_data_builder.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Declares builder of OGLE data."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import re
+import os
+import os.path
+
+from justice import ogle_data
+
+
+# NOTE(gatoatigrado): Add new filename matches as necessary.
+_extract_name = re.compile(r"(OGLE-LMC-CEP-\d+).dat")
+
+
+def _dat_files(directory):
+    matches = [_extract_name.match(filename) for filename in os.listdir(directory)]
+    return [(match.group(0), match.group(1)) for match in matches]
+
+
+def build(ogle3_data_dir, ia_descriptor, expected_bands=('I', 'V')):
+    """Builds a binary OGLE dataset from original .DAT files.
+
+    :param ogle3_data_dir: OGLE-3 data dir.
+    :type ogle3_data_dir: str
+    :param ia_descriptor: Descriptor of where to save data.
+    :type ia_descriptor: justice.mmap_array.IndexedArrayDescriptor
+    :param expected_bands: Expected bands.
+    """
+    band_dirs = [os.path.join(ogle3_data_dir, band) for band in expected_bands]
+    for band_dir in band_dirs:
+        if not os.path.isdir(band_dir):
+            raise OSError("Expected directory {} to exist.".format(band_dir))
+
+    band_names = sorted(
+        frozenset.
+        intersection(*[frozenset(_dat_files(band_dir)) for band_dir in band_dirs])
+    )
+
+    if not band_names:
+        raise ValueError("Expected filenames to be shared.")
+
+    index_rows = []
+    data = []
+    for filename, id_str in band_names:
+        for band, band_dir in zip(expected_bands, band_dirs):
+            index_rows.append({
+                'id': id_str,
+                'band': band,
+            })
+            with open(os.path.join(band_dir, filename)) as f:
+                contents = [
+                    list(map(float,
+                             line.strip().split()))
+                    for line in f.read().strip().splitlines()
+                ]
+            data.append(contents)
+
+    ia_descriptor.write(index_rows, data)
+
+
+def main():
+    cmd_args = argparse.ArgumentParser()
+    cmd_args.add_argument("--name", required=True)
+    cmd_args.add_argument("--data-directory", required=True)
+    cmd_args.add_argument("--expected-bands", default="I,V", help="Expected band names.")
+    args = cmd_args.parse_args()
+
+    expected_bands = tuple(args.expected_bands.split(','))
+    ia_descriptor = ogle_data.for_subset(args.name)
+    build(args.data_directory, ia_descriptor, expected_bands=expected_bands)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/mmap_array_test.py
+++ b/test/mmap_array_test.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Basic tests for writing mmap arrays."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from justice import mmap_array
+
+
+def test_write_indexed(tmpdir):
+    index_rows = [
+        {
+            'id': 1234,
+            'band': 'i'
+        },
+        {
+            'id': 342,
+            'band': 'z'
+        },
+        {
+            'id': 613,
+            'band': 'i'
+        },
+        {
+            'id': 613,
+            'band': 'z'
+        },
+    ]
+    data = [
+        [(123, 4, 1), (123, 5, 1)],
+        [(34, 4, 1)],
+        [(61.1, 4, 10), (61.2, 4, 10)],
+        [(61, 4, 1), (61.3, 4, 1)],
+    ]
+    descriptor = mmap_array.IndexedArrayDescriptor(
+        base_dir=tmpdir.mkdir("test_write_indexed")
+    )
+    assert descriptor.index_filename.endswith("index_df.pickle")
+
+    descriptor.write(index_rows, data)
+    ia = descriptor.read()
+    assert ia.index_df.iloc[0].start == 0
+    assert ia.index_df.iloc[0].end == 2
+    assert ia.index_df.iloc[1].start == 2
+    assert ia.index_df.iloc[1].end == 3
+
+    assert ia.get_data(ia.index_df.iloc[0]).tolist() == [[123.0, 4.0, 1.0],
+                                                         [123.0, 5.0, 1.0]]
+    assert ia.get_data(ia.index_df.iloc[3]).tolist() == [[61.0, 4.0, 1.0],
+                                                         [61.3, 4.0, 1.0]]


### PR DESCRIPTION
Seems to work, but I want to add functionality to work with the star tables, so we get solution IDs and such.

```
(venv3) cassandra:~/sandbox/justice> python3 -m justice.ogle_data_builder --name cep --data-dir ~/Downloads/ogle_data_lmc_cep
Wrote dataset in /Users/gatoatigrado/sandbox/justice/data/mmap_arrays/ogle_iii/cep/index_df.pickle with 6656 light curves
```