### PR TITLE
Make _expected_bands public, add a per-band normalizing transform

### DIFF
--- a/Alignment Examples.ipynb
+++ b/Alignment Examples.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "from justice import xform\n",
     "from justice import summarize\n",
-    "from justice import supernova_data\n",
+    "from justice import ogle_data\n",
     "from justice import visualize"
    ]
   },
@@ -23,13 +23,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sn_dataset = supernova_data.SNDataset()\n",
-    "df = sn_dataset.index_df[sn_dataset.index_df['type'] != -9]\n",
+    "cep_dataset = ogle_data.OgleDataset.read_for_name(\"cep\")\n",
+    "df = cep_dataset.index_df\n",
     "\n",
     "type_to_ids = {}\n",
-    "for key, subframe in df.sort_values('type').groupby('type'):\n",
+    "for key, subframe in df.sort_values('Subtype').groupby('Subtype'):\n",
     "    type_to_ids.setdefault(key, [])\n",
-    "    type_to_ids[key].extend(sorted(frozenset(subframe['id'].tolist())))"
+    "    type_to_ids[key].extend(sorted(frozenset(subframe.index.tolist())))"
    ]
   },
   {
@@ -40,27 +40,22 @@
    "source": [
     "# Choose 2 random light curves of the same type.\n",
     "\n",
-    "# The SN dataset generation may differ, so just hardcode the IDs for now.\n",
-    "#\n",
-    "# rng = random.Random(89794)\n",
-    "# random_type = rng.choice(sorted(type_to_ids.keys()))\n",
-    "# random_ids = rng.sample(type_to_ids[random_type], 2)\n",
-    "random_type = 3\n",
-    "random_ids = [35417, 13810]\n",
+    "# The dataset generation may differ, so just hardcode the IDs for now.\n",
+    "random_type = 'F1'\n",
+    "random_ids = ['OGLE-LMC-CEP-0432', 'OGLE-LMC-CEP-0507']\n",
+    "assert frozenset(random_ids) <= frozenset(type_to_ids[random_type])\n",
     "\n",
-    "lca = supernova_data.format_dense_multi_band_from_lc_dict(\n",
-    "    sn_dataset.lc_dict_for_id(random_ids[0])\n",
-    ")\n",
-    "lcb = supernova_data.format_dense_multi_band_from_lc_dict(\n",
-    "    sn_dataset.lc_dict_for_id(random_ids[1])\n",
-    ")\n",
-    "lca = xform.Aff(tx=-np.mean(lca.x)).transform(lca)\n",
-    "lcb = xform.Aff(tx=-np.mean(lcb.x)).transform(lcb)\n",
+    "def load_for_id(random_id):\n",
+    "    lc = cep_dataset.lc_for_id(random_id)\n",
+    "    return lc.per_band_normalization(1000.0).transform(lc)\n",
+    "\n",
+    "lca = load_for_id(random_ids[0])\n",
+    "lcb = load_for_id(random_ids[1])\n",
     "visualize.plot_single_lc_color_bands(\n",
     "    lca, \"{}, type {}\".format(random_ids[0], random_type)\n",
     ")\n",
     "visualize.plot_single_lc_color_bands(\n",
-    "    lcb, \"{}, type {}\".format(random_ids[1], random_type)\n",
+    "   lcb, \"{}, type {}\".format(random_ids[1], random_type)\n",
     ")\n",
     "None  # Here and below: Avoid plot showing up twice by setting cell return value to None."
    ]
@@ -110,7 +105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/Visualize_data.ipynb
+++ b/Visualize_data.ipynb
@@ -176,10 +176,10 @@
     "    rows_and_data = cep_dataset.lcs_for_id(random_id)\n",
     "    plt.figure(figsize=(12, 6))\n",
     "    plt.title(\"{}, type Cep-{}\".format(random_id, rows_and_data[0][0].Subtype))\n",
-    "    \n",
-    "    for row, lc_data in rows_and_data:\n",
+    "\n",
+    "    for band, band_data in cep_dataset.lc_for_id(random_id).bands.items():\n",
     "        # This dataset doesn't seem to have that many points, so larger markers are OK.\n",
-    "        plt.errorbar(lc_data[:, 0], lc_data[:, 1], yerr=lc_data[:, 2], fmt='o', color=colormap[row.band])"
+    "        plt.errorbar(band_data.time, band_data.flux, yerr=band_data.flux_err, fmt='o', color=colormap[band])"
    ]
   }
  ],

--- a/justice/ogle_data.py
+++ b/justice/ogle_data.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import os.path
 import random
 
-from justice import mmap_array
+from justice import mmap_array, lightcurve
 
 ogle_dir = os.path.join(mmap_array.default_array_dir, 'ogle_iii')
 
@@ -41,18 +41,21 @@ class OgleDataset(mmap_array.IndexedArray):
             row_and_data.append((row, data))
         return row_and_data
 
-    def lc_dict_for_id(self, id_):
-        """Returns a dictionary mapping band to light curve array.
+    def lc_for_id(self, id_):
+        """Returns a light curve for an ID.
 
         :param id_: ID to get data for.
         :return: Dict from band ('i', 'r', etc.) to [num_points, 3]-shaped array.
             The first column is time, second is flux, third is flux error.
         """
         row_and_data = self.lcs_for_id(id_)
-        result = {row.band: array for row, array in row_and_data}
+        result = {
+            row.band: lightcurve.BandData.from_dense_array(array)
+            for row, array in row_and_data
+        }
         if len(row_and_data) != len(result):
             raise ValueError("band does not uniquely identify sub-ranges")
-        return result
+        return lightcurve.OGLEDatasetLC(**result)
 
     @classmethod
     def read_for_name(cls, name):

--- a/justice/simulate.py
+++ b/justice/simulate.py
@@ -52,7 +52,7 @@ def make_dataset(num_obj, xs, shape_fn, cls_wts=None):
 
 class TestLC(lightcurve._LC):
     @property
-    def _expected_bands(self):
+    def expected_bands(self):
         return ['b']
 
     @classmethod

--- a/test/lightcurve_test.py
+++ b/test/lightcurve_test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Tests for the light curve class."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from justice import lightcurve
+
+
+def _assert_near(a, b, eps=1e-5):
+    a = np.array(a, copy=False)
+    b = np.array(b, copy=False)
+    assert np.mean(np.abs(a - b)) < eps, "{} not close to {}".format(a, b)
+
+
+def test_per_band_centering():
+    first = lightcurve.BandData.from_dense_array(
+        np.array([
+            [1, 10, 0.1],
+            [2, 11, 0.11],
+            [3, 12, 0.1],
+            [4, 12, 0.1],
+            [5, 12, 0.12],
+        ])
+    )
+    second = lightcurve.BandData.from_dense_array(
+        np.array([
+            [4.7, 1, 0.1],
+            [5, 2, 0.14],
+        ])
+    )
+    lc = lightcurve.OGLEDatasetLC(I=first, V=second)
+    xf = lc.per_band_normalization(100.0)
+    lct = xf.transform(lc)
+    _assert_near(lct['I'].time, [-2.15, -1.15, -0.15, 0.85, 1.85])
+    _assert_near(lct['V'].time, [1.55, 1.85])
+    _assert_near(np.max(lct['I'].flux), 100)
+    _assert_near(np.max(lct['V'].flux), 100)

--- a/test/ogle_data_test.py
+++ b/test/ogle_data_test.py
@@ -25,10 +25,11 @@ def test_build_and_get_random(testdata_dir, tmpdir):
 
     test_dataset = ogle_data.OgleDataset.read_for_name("test_name")
     assert test_dataset.all_ids == ['OGLE-LMC-CEP-0001', 'OGLE-LMC-CEP-0002']
-    lc_dict = test_dataset.lc_dict_for_id('OGLE-LMC-CEP-0001')
+    lc = test_dataset.lc_for_id('OGLE-LMC-CEP-0001')
     assert test_dataset['OGLE-LMC-CEP-0002'].field.tolist() == ['LMC157.6', 'LMC157.6']
-    assert lc_dict.keys() == {"I", "V"}
-    sample_data = lc_dict["I"][0:2, :].tolist()
-    expected = [[479.65878256202586, 8.154761695700554e-08, 6.624523579080573e-11],
-                [1273.9239423496151, 9.080244446205889e-08, 8.940833243072116e-11]]
-    assert sample_data == expected
+    assert lc.bands.keys() == {"I", "V"}
+    assert lc["I"].time[0:2].tolist() == [479.65878256202586, 1273.9239423496151]
+    assert lc["I"].flux[0:2].tolist() == [8.154761695700554e-08, 9.080244446205889e-08]
+    assert lc["I"].flux_err[0:2].tolist() == [
+        6.624523579080573e-11, 8.940833243072116e-11
+    ]


### PR DESCRIPTION
The per-band normalizing transform scales all bands to the same 'y' scale, and shifts them so the time window is approximately centered.

I used np.percentile([5, 95]) so that it would be less sensitive to cases where one band is sampled more at the end of the time scale or such.