### PR TITLE
Import csv to bcolz

### DIFF
--- a/justice/datasets/README_bcolz.md
+++ b/justice/datasets/README_bcolz.md
@@ -1,0 +1,13 @@
+# Instructions for bcolz format
+
+## Generating data from Kaggle CSV files
+
+Using zsh,
+
+```sh
+for i in data/(training|test)_set(|_metadata).csv; do
+    python3 -m justice.datasets.plasticc_bcolz --source-file $i;
+done
+```
+
+

--- a/justice/datasets/README_bcolz.md
+++ b/justice/datasets/README_bcolz.md
@@ -5,9 +5,12 @@
 Using zsh,
 
 ```sh
-for i in data/(training|test)_set(|_metadata).csv; do
+for i in data/(training|test)_set_metadata.csv data/(training|test)_set.csv; do
     python3 -m justice.datasets.plasticc_bcolz --source-file $i;
 done
 ```
+
+(The above invocation splits metadata and test set csv generation,
+so if there are errors it will fail faster.)
 
 

--- a/justice/datasets/plasticc_bcolz.py
+++ b/justice/datasets/plasticc_bcolz.py
@@ -17,20 +17,6 @@ from justice import path_util
 _root_dir = path_util.data_dir / 'plasticc_bcolz'
 
 
-def get_tree_size(path):
-    """Return total size of files in given path and subdirs.
-
-    Copied from https://www.python.org/dev/peps/pep-0471/ (public domain).
-    """
-    total = 0
-    for entry in os.scandir(path):
-        if entry.is_dir(follow_symlinks=False):
-            total += get_tree_size(entry.path)
-        else:
-            total += entry.stat(follow_symlinks=False).st_size
-    return total
-
-
 class BcolzDataset(object):
     def __init__(self, bcolz_dir):
         self.bcolz_dir = bcolz_dir
@@ -89,7 +75,7 @@ def create_dataset(*, source_file, out_dir):
         table.append(cols=[next_chunk[col] for col in column_names])
     table.flush()
     num_rows = table.shape[0]
-    size_mb = get_tree_size(out_dir) / (1024.0**2)
+    size_mb = table.cbytes / (1024.0**2)
     print(
         f"Created bcolz table with {num_rows} rows, compression settings "
         f"{table.cparams}, final size {size_mb:.1f} MiB"

--- a/justice/datasets/plasticc_bcolz.py
+++ b/justice/datasets/plasticc_bcolz.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""Imports PLasTiCC datasets to bcolz."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import csv
+import json
+import os.path
+import shutil
+import subprocess
+
+import bcolz
+
+from justice import path_util
+
+_root_dir = path_util.data_dir / 'plasticc_bcolz'
+
+_col_to_data_type = {
+    'object_id': 'i4',
+    'mjd': 'f4',
+    'passband': 'i4',
+    'flux': 'f4',
+    'flux_err': 'f4',
+    'detected': 'i1',
+    'ra': 'f4',
+    'decl': 'f4',
+    'gal_l': 'f4',
+    'gal_b': 'f4',
+    'ddf': 'i4',
+    'hostgal_specz': 'f4',
+    'hostgal_photoz': 'f4',
+    'hostgal_photoz_err': 'f4',
+    'distmod': 'f4',
+    'mwebv': 'f4',
+    'target': 'i4',
+}
+_col_to_converter = {
+    key: (
+        int if value.startswith("i") else
+        (float if value.startswith("f") else NotImplemented)
+    )
+    for key, value in _col_to_data_type.items()
+}
+
+
+class BcolzDataset(object):
+    def __init__(self, bcolz_dir):
+        self.bcolz_dir = bcolz_dir
+
+        if not bcolz_dir.parent.is_dir():
+            os.makedirs(str(bcolz_dir.parent))
+
+    def read_table(self):
+        return bcolz.open(self.bcolz_dir, 'r')
+
+    def clear_files(self):
+        if self.bcolz_dir.exists():
+            if input(f"Type 'y' to delete existing {self.bcolz_dir}: ").strip() != "y":
+                raise EnvironmentError("Output directory already exists!")
+            assert "plasticc" in str(self.bcolz_dir)  # rmtree safety
+            shutil.rmtree(str(self.bcolz_dir))
+
+    @property
+    def column_names_json(self):
+        return self.bcolz_dir / "column_names.json"
+
+    def write_column_names(self, column_names):
+        assert isinstance(column_names, list)
+        with open(self.column_names_json, 'w') as f:
+            json.dump(column_names, f)
+
+    def read_column_names(self):
+        with open(self.column_names_json, 'r') as f:
+            return json.load(f)
+
+
+def create_dataset(*, csv_reader, out_dir, num_rows):
+    first_row = next(csv_reader)
+    types = ",".join(_col_to_data_type[col] for col in first_row.keys())
+    converters = [_col_to_converter[col] for col in first_row.keys()]
+
+    def _data_gen():
+        num_read = 0
+        first_row_values = tuple(c(v) for c, v in zip(converters, first_row.values()))
+        print(f"First row: {first_row_values}")
+        yield first_row_values
+        num_read += 1
+        for row in csv_reader:
+            yield tuple(c(v) for c, v in zip(converters, row.values()))
+            num_read += 1
+            if num_read % 1_000_000 == 0:
+                print(f"    Read {num_read} rows ...")
+        assert num_read == num_rows, f"Estimate of number of rows {num_rows} != actual {num_read}!"
+
+    print(f"Generating bcolz table with {num_rows} rows, data types {types}")
+    gen = _data_gen()
+    table = bcolz.fromiter(gen, dtype=types, count=num_rows, rootdir=str(out_dir))
+    try:
+        next(gen)
+        raise ValueError("Not all rows consumed!")
+    except StopIteration:
+        return first_row, table
+
+
+def main():
+    cmd_args = argparse.ArgumentParser()
+    cmd_args.add_argument("--name")
+    cmd_args.add_argument("--source-file", required=True)
+    args = cmd_args.parse_args()
+
+    if args.name is None:
+        args.name = os.path.basename(args.source_file).replace(".csv", "")
+    out_dir = _root_dir / args.name
+    dataset = BcolzDataset(out_dir)
+
+    dataset.clear_files()  # prompt and clear files if they exist.
+
+    print("Scanning number of rows")
+    with open(args.source_file, newline='') as csvfile:
+        reader = csv.reader(csvfile)
+        header_row = next(reader)
+        for name in header_row:
+            assert name in _col_to_data_type, f"Unknown column {name}"
+        wc_output = subprocess.check_output(["wc", "-l", args.source_file])
+        num_rows = int(wc_output.strip().split()[0]) - 1  # has a header
+
+    with open(args.source_file, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        first_row, table = create_dataset(
+            csv_reader=reader, num_rows=num_rows, out_dir=out_dir
+        )
+        del table  # unused
+
+    dataset.write_column_names(list(first_row.keys()))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Seems pretty fast and nice so far! Thanks to Ted for the suggestion!

```
> echo y | time python3 -m justice.datasets.plasticc_bcolz --source-file data/training_set.csv
Type 'y' to delete existing /home/gatoatigrado/sandbox/justice/data/plasticc_bcolz/training_set:
Created bcolz table with 1421705 rows, compression settings cparams(clevel=3, shuffle=1, cname='lz4hc', quantize=0), final size 12.4 MiB
python3 -m justice.datasets.plasticc_bcolz --source-file data/training_set.cs  1.42s user 0.41s system 135% cpu 1.351 total
```

Test:

```
> ipython
Python 3.6.6 (default, Sep 12 2018, 18:26:19)
Type 'copyright', 'credits' or 'license' for more information
IPython 6.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import bcolz

In [2]: table = bcolz.open('data/plasticc_bcolz/test_set', 'r')

In [3]: table[1000:1010]
Out[3]: 
array([(17, 60616.027, 0,  2.039181, 1.699975, 0),
       (17, 60617.03 , 0,  0.093869, 1.314118, 0),
       (17, 60621.17 , 2, -0.011564, 0.922144, 0),
       (17, 60621.18 , 1,  0.306673, 0.886037, 0),
       (17, 60621.188, 3,  1.168951, 1.593608, 0),
       (17, 60621.2  , 4,  0.037488, 2.580779, 0),
       (17, 60621.21 , 5,  6.122403, 6.875967, 0),
       (17, 60624.176, 2,  1.567006, 1.670252, 0),
       (17, 60624.184, 1,  2.871525, 2.27956 , 0),
       (17, 60624.19 , 3,  0.625059, 2.184968, 0)],
      dtype=[('object_id', '<i4'), ('mjd', '<f4'), ('passband', '<i4'), ('flux', '<f4'), ('flux_err', '<f4'), ('detected', 'i1')])
```