### PR TITLE
Start synthetic positives generation

### DIFF
--- a/justice/align_model/lr_prefixing.py
+++ b/justice/align_model/lr_prefixing.py
@@ -20,9 +20,13 @@ def lr_per_side_sub_model_fn(sub_model_fn, features, params):
 
 
 def prefix_tensors(left: dict, right: dict):
-    result = {}
     left = graph_typecheck.assert_tensor_dict(left)
     right = graph_typecheck.assert_tensor_dict(right)
+    return prefix_dicts(left, right)
+
+
+def prefix_dicts(left: dict, right: dict):
+    result = {}
     for k, v in left.items():
         result[f"left.{k}"] = v
     for k, v in right.items():

--- a/justice/align_model/synthetic_positives.py
+++ b/justice/align_model/synthetic_positives.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""Generates synthetic positive data."""
+import math
+import random
+import typing
+
+import numpy as np
+import tensorflow as tf
+
+from justice import xform, lightcurve
+from justice.align_model import lr_prefixing
+from justice.features import band_settings_params, raw_value_features, tf_dataset_builder
+
+
+class FullPositivesPair:
+    """Simple struct for a pair of positive examples.
+
+    The meaning is that `time_a` of light curve `lca` should be aligned with `time_b` of
+    light curve `lcb`. For the current alignment model, we do not have other gold/intended
+    transformation parameters, we merely hope that points having the best alignment will
+    lead to reasonable inference of dilation.
+    """
+
+    __slots__ = ("lca", "lcb", "time_a", "time_b")
+
+    def __init__(
+        self, lca: lightcurve._LC, lcb: lightcurve._LC, time_a: float, time_b: float
+    ):
+        self.lca = lca
+        self.lcb = lcb
+        self.time_a = time_a
+        self.time_b = time_b
+
+
+class BasicPositivesGenerator:
+    """Generates positive example pairs by transforming a light curve.
+
+    For non-test data, we could consider estimating the range of shifts/dilations by
+    target, for example if we see that variable objects have a period within [x, 3x]
+    (for some x) then we could consider dilate_time_stdev_factor=3.
+    """
+
+    def __init__(
+        self,
+        *,
+        translate_time_stdev=1.0,
+        translate_flux_stdev=0.01,
+        dilate_time_stdev_factor=1.1,
+        dilate_flux_stdev_factor=1.5,
+        rng: random.Random = None
+    ):
+        self.translate_time_stdev = translate_time_stdev
+        self.translate_flux_stdev = translate_flux_stdev
+
+        if dilate_time_stdev_factor < 1.0:
+            raise ValueError("dilate_time_stdev_factor must be >= 1.")
+        if dilate_flux_stdev_factor < 1.0:
+            raise ValueError("dilate_flux_stdev_factor must be >= 1.")
+
+        self.log_dilate_time_stdev = math.log(dilate_time_stdev_factor)
+        self.log_dilate_flux_stdev = math.log(dilate_flux_stdev_factor)
+        self.rng = random.Random() if rng is None else rng
+
+    def make_xform(self):
+        translate_time = self.rng.normalvariate(0, self.translate_time_stdev)
+        translate_flux = self.rng.normalvariate(0, self.translate_flux_stdev)
+        log_dilate_time = self.rng.normalvariate(0, self.log_dilate_time_stdev)
+        log_dilate_flux = self.rng.normalvariate(0, self.log_dilate_flux_stdev)
+        return xform.LinearBandDataXform(
+            translate_time,
+            translate_flux,
+            dilate_time=math.exp(log_dilate_time),
+            dilate_flux=math.exp(log_dilate_flux),
+            check_positive=True,
+        )
+
+    def make_positive_pair(self, lc: lightcurve._LC) -> FullPositivesPair:
+        time = float(self.rng.choice(lc.all_times_unique()))
+        xf = self.make_xform()
+        lc_xf = xform.SameLCXform(xf)
+        transformed = lc_xf.apply(lc)
+        time_transformed: float = xf.apply_time(time)
+        return FullPositivesPair(
+            lca=lc, time_a=time, lcb=transformed, time_b=time_transformed
+        )
+
+
+class RandomSubsampler(xform.BandDataXform):
+    """Band data transformer that samples points within a band.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_rate: float,
+        max_rate: float,
+        preserve_time: float,
+        preserve_time_radius: float = 4.0,
+        rng: np.random.RandomState = None
+    ):
+        self.rng = rng if rng is not None else np.random.RandomState()
+        self.preserve_time = preserve_time
+        self.preserve_time_radius = preserve_time_radius
+        self.min_rate = min_rate
+        self.max_rate = max_rate
+
+    def apply(self, band):
+        indices = np.arange(0, len(band.time))
+        preserve_mask = np.abs(band.time -
+                               self.preserve_time) < self.preserve_time_radius
+        preserved = indices[preserve_mask]
+        indices = indices[~preserve_mask]
+        num_points = len(indices)
+        hard_min_size = min(num_points, 2)  # usually 2 but allow lower if very small
+        min_size = max(hard_min_size, int(self.min_rate * num_points))
+        max_size = int(math.ceil(self.max_rate * num_points))
+        sample_size = self.rng.randint(min_size, max_size)
+        sample_indices = np.sort(
+            np.concatenate([
+                preserved,
+                self.rng.choice(indices, size=sample_size, replace=False)
+            ])
+        )
+        return lightcurve.BandData(
+            time=band.time[sample_indices],
+            flux=band.flux[sample_indices],
+            flux_err=band.flux_err[sample_indices],
+            detected=band.detected[sample_indices]
+        )
+
+    def apply_time(self, time: typing.Union[float, np.ndarray]):
+        return time
+
+
+class PositivePairSubsampler:
+    def __init__(
+        self,
+        *,
+        min_rate: float = 0.5,
+        max_rate: float = 1.0,
+        preserve_time_radius: float = 4.0,
+        rng: np.random.RandomState = None
+    ):
+        self.rng = rng if rng is not None else np.random.RandomState()
+        self.preserve_time_radius = preserve_time_radius
+        self.min_rate = min_rate
+        self.max_rate = max_rate
+
+    def lc_xform(self, time: float) -> xform.SameLCXform:
+        band_xform = RandomSubsampler(
+            min_rate=self.min_rate,
+            max_rate=self.max_rate,
+            preserve_time=time,
+            preserve_time_radius=self.preserve_time_radius,
+            rng=self.rng
+        )
+        return xform.SameLCXform(band_xform)
+
+    def apply(self, fpp: FullPositivesPair) -> FullPositivesPair:
+        lca_xf = self.lc_xform(fpp.time_a)
+        lcb_xf = self.lc_xform(fpp.time_b)
+        return FullPositivesPair(
+            lca=lca_xf.apply(fpp.lca),
+            lcb=lcb_xf.apply(fpp.lcb),
+            time_a=fpp.time_a,
+            time_b=fpp.time_b
+        )
+
+
+class RawValuesFullPositives:
+    def __init__(self, bands, window_size):
+        self.band_settings = band_settings_params.BandSettings(bands=bands)
+        self.fex = raw_value_features.RawValueExtractor(
+            window_size=window_size, band_settings=self.band_settings
+        )
+
+    def apply(self, fpp: FullPositivesPair) -> typing.Dict[str, tf.Tensor]:
+        first_features = self.fex.extract(fpp.lca, fpp.time_a)
+        second_features = self.fex.extract(fpp.lcb, fpp.time_b)
+        result = lr_prefixing.prefix_dicts(first_features, second_features)
+        result["labels"] = True
+        return result
+
+    def make_dataset(
+        self, fpp_gen: typing.Iterator[FullPositivesPair]
+    ) -> tf.data.Dataset:
+        return tf_dataset_builder.dataset_from_generator_auto_dtypes(
+            self.apply(fpp) for fpp in fpp_gen
+        )
+
+    @classmethod
+    def from_params(cls, params: dict):
+        return cls(params["lc_bands"], params["window_size"])

--- a/justice/datasets/plasticc_data.py
+++ b/justice/datasets/plasticc_data.py
@@ -138,6 +138,13 @@ class PlasticcDatasetLC(lightcurve._LC):
 
     expected_bands = list('ugrizy')
 
+    def get_string_name(self):
+        return "Object {}".format(self.meta.get("object_id", "NO_OBJECT_ID")) + (
+            ", target {}".format(self.meta['target']) if 'target' in self.meta else ""
+        ) + (
+            " ￮ " + self.meta["last_transform"] if "last_transform" in self.meta else ""
+        )
+
     @classmethod
     def _get_band_from_raw(cls, conn, dataset, obj_id, band_id):
 

--- a/justice/features/tf_dataset_builder.py
+++ b/justice/features/tf_dataset_builder.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Helpers for building TF datasets."""
+import numpy as np
+import tensorflow as tf
+
+
+def auto_dtype(key, value):
+    if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.floating):
+        return tf.float32
+    elif isinstance(value, (float, np.floating)):
+        return tf.float32
+    elif isinstance(value, (int, np.integer)):
+        return tf.int64
+    elif isinstance(value, (bool, np.bool_)):
+        return tf.bool
+    elif '_padding' in key:
+        assert isinstance(
+            value, int
+        ) or (isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer))
+        return tf.int32
+    else:
+        typ = type(value.dtype)
+        raise ValueError(
+            f"Unrecognized data type for key {key!r}, value {value.dtype!r} ({typ})"
+        )
+
+
+def auto_shape(value):
+    if isinstance(value, np.ndarray):
+        return value.shape
+    else:
+        return ()
+
+
+def dataset_from_generator_auto_dtypes(generator):
+    print("dataset_from_generator_auto_dtypes")
+    first_features = next(generator)
+    dtypes = {key: auto_dtype(key, value) for key, value in first_features.items()}
+    shapes = {key: auto_shape(value) for key, value in first_features.items()}
+
+    def gen():
+        yield first_features
+        yield from generator
+
+    return tf.data.Dataset.from_generator(gen, output_types=dtypes, output_shapes=shapes)

--- a/justice/visualize.py
+++ b/justice/visualize.py
@@ -97,19 +97,20 @@ def plot_lcs(
         squeeze=False
     )
 
-    fig.suptitle(title)
+    if title:
+        fig.suptitle(title)
 
     for i, b in enumerate(bands):
         for lci in lcs:
             detec = lci.bands[b].detected
-            ax[i, 0].errorbar(
+            detected_plot = ax[i, 0].errorbar(
                 lci.bands[b].time[detec == 1],
                 lci.bands[b].flux[detec == 1],
                 yerr=lci.bands[b].flux_err[detec == 1],
                 linestyle='None',
                 marker='.'
             )
-            ax[i, 0].errorbar(
+            not_detected_plot = ax[i, 0].errorbar(
                 lci.bands[b].time[detec == 0],
                 lci.bands[b].flux[detec == 0],
                 yerr=lci.bands[b].flux_err[detec == 0],
@@ -117,6 +118,8 @@ def plot_lcs(
                 alpha=.2,
                 marker='.'
             )
+            plt.legend([detected_plot, not_detected_plot], ["detected", "not detected"],
+                       loc="upper right")
 
         if i == numbands - 1:
             ax[i, 0].set_xlabel('time')  # Only set on bottom plot.
@@ -130,7 +133,10 @@ def plot_lcs(
     plt.ylabel(b).set_rotation(0)
     plt.xlabel('time')
     plt.subplots_adjust(hspace=0.4)
-    plt.tight_layout()
+    if title:
+        fig.tight_layout(rect=[0, 0.03, 1, 0.95])
+    else:
+        plt.tight_layout()
     if isinstance(save, str):
         plt.savefig(save, dpi=250)
     return fig

--- a/justice/xform.py
+++ b/justice/xform.py
@@ -1,3 +1,5 @@
+import typing
+
 import numpy as np
 from justice import lightcurve
 import abc
@@ -28,8 +30,7 @@ class BandNameMapper:
             this_e = lc.expected_bands[i]
             next_e = lc.expected_bands[i + 1]
             assert self.pwavs[this_e] < self.pwavs[
-                next_e
-            ], 'Bands must be mapped to increasing pwavs'
+                next_e], 'Bands must be mapped to increasing pwavs'
         pwav = np.concatenate([
             np.ones_like(lc.bands[b].time) * self.pwavs[b] for b in lc.expected_bands
         ])
@@ -47,6 +48,9 @@ class BandDataXform:
         self._flux_fn = flux_fn
         self._flux_err_fn = flux_err_fn
 
+    def __str__(self):
+        return "BandDataXform[]"
+
     def apply(self, bd) -> lightcurve.BandData:
         return lightcurve.BandData(
             self._time_fn(bd.time),
@@ -55,20 +59,45 @@ class BandDataXform:
             bd.detected,
         )
 
+    def apply_time(self, time: typing.Union[float, np.ndarray]):
+        return self._time_fn(time)
+
 
 class LinearBandDataXform(BandDataXform):
-    def __init__(self, translate_time, translate_flux, dilate_time, dilate_flux):
+    def __init__(
+        self,
+        translate_time,
+        translate_flux,
+        dilate_time,
+        dilate_flux,
+        check_positive=True
+    ):
         self._translate_time = translate_time
         self._translate_flux = translate_flux
         self._dilate_time = dilate_time
         self._dilate_flux = dilate_flux
+        if check_positive:
+            if dilate_time <= 0:
+                raise ValueError("Expected dilate_time to be positive.")
+            if dilate_flux <= 0:
+                raise ValueError("Expected dilate_flux to be positive.")
+
+    def __str__(self):
+        return (
+            "LinearBandDataXform["
+            f"t → {self._dilate_time:.2f} (t + {self._translate_time:.2f}), "
+            f"flux → {self._dilate_flux:.2f} (flux + {self._translate_flux:.2f})]"
+        )
 
     def apply(self, bd) -> lightcurve.BandData:
         new_x = self._dilate_time * (bd.time + self._translate_time)
         new_y = self._dilate_flux * (bd.flux + self._translate_flux)
         # TODO: does error really behave this way?
         new_yerr = np.sqrt(self._dilate_flux) * bd.flux_err
-        return lightcurve.BandData(new_x, new_y, new_yerr)
+        return lightcurve.BandData(new_x, new_y, new_yerr, detected=bd.detected)
+
+    def apply_time(self, time: typing.Union[float, np.ndarray]):
+        return self._dilate_time * (time + self._translate_time)
 
 
 class LCXform:
@@ -100,14 +129,20 @@ class IndependentLCXform(LCXform):
 class SameLCXform(LCXform):
     """All bands get the same transform"""
 
-    def __init__(self, band_xform):
+    def __init__(self, band_xform: BandDataXform) -> None:
         self._band_xform = band_xform
 
     def apply(self, lc) -> lightcurve._LC:
         new_bands = {}
         for name in lc.bands:
             new_bands[name] = self._band_xform.apply(lc.bands[name])
-        return lc.__class__(**new_bands)
+        result = lc.__class__(**new_bands)
+        result.meta.update(lc.meta)
+        result.meta["last_transform"] = str(self._band_xform)
+        return result
+
+    def apply_time(self, time: typing.Union[float, np.ndarray]):
+        return self._band_xform.apply_time(time)
 
 
 class LC2DXform:

--- a/test/align_model/synthetic_positives_test.py
+++ b/test/align_model/synthetic_positives_test.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Tests for synthetic positives generation."""
+import random
+
+import numpy as np
+import tensorflow as tf
+
+from justice import simulate
+from justice.align_model import synthetic_positives
+
+
+def test_xform_params_distribution():
+    pg = synthetic_positives.BasicPositivesGenerator(
+        dilate_time_stdev_factor=2.0,
+        dilate_flux_stdev_factor=3.0,
+        rng=random.Random(1234)
+    )
+    xforms = [pg.make_xform() for _ in range(1000)]
+    time_dilations = [xf._dilate_time for xf in xforms]
+    flux_dilations = [xf._dilate_flux for xf in xforms]
+
+    # TODO(gatoatigrado): This time variation is too much. Look at
+    # scipy.stats.truncnorm or do rejection sampling.
+    assert 0.01 < min(time_dilations)
+    assert max(time_dilations) < 16
+    assert 0.01 < min(flux_dilations)
+    assert max(flux_dilations) < 24
+    assert abs(np.median(time_dilations) - 1.0) < 0.05
+    assert abs(np.median(flux_dilations) - 1.0) < 0.05
+
+    first_percentile_time_dilations = np.percentile(time_dilations, 50 + 35)
+    first_percentile_flux_dilations = np.percentile(flux_dilations, 50 + 35)
+    assert abs(first_percentile_time_dilations - 2.0) < 0.1
+    assert abs(first_percentile_flux_dilations - 3.0) < 0.1
+
+
+def _total_points(fpp: synthetic_positives.PositivePairSubsampler):
+    return fpp.lca.total_points_all_bands(), fpp.lcb.total_points_all_bands()
+
+
+def test_smoke_subsampler():
+    pg = synthetic_positives.BasicPositivesGenerator(
+        dilate_time_stdev_factor=2.0,
+        dilate_flux_stdev_factor=3.0,
+        rng=random.Random(1234)
+    )
+    pair_subsampler = synthetic_positives.PositivePairSubsampler(
+        rng=np.random.RandomState(123)
+    )
+    fpp = pg.make_positive_pair(simulate.TestLC.make_realistic_gauss())
+    fpp2 = pair_subsampler.apply(fpp)
+    assert _total_points(fpp) == (115, 115)
+    assert _total_points(fpp2) == (104, 78)
+
+
+def test_feature_extraction(tf_sess):
+    pg = synthetic_positives.BasicPositivesGenerator(
+        dilate_time_stdev_factor=2.0,
+        dilate_flux_stdev_factor=3.0,
+        rng=random.Random(1234)
+    )
+    params = {"batch_size": 20, "window_size": 10, "lc_bands": ["b"]}
+    rv_fex = synthetic_positives.RawValuesFullPositives.from_params(params)
+    lcs = [simulate.TestLC.make_realistic_gauss(scale) for scale in [10.0, 15.0, 30.0]]
+    fpp_gen = (pg.make_positive_pair(lc) for lc in lcs)
+    dataset = rv_fex.make_dataset(fpp_gen)
+    assert isinstance(dataset, tf.data.Dataset)
+    get_next_tensor = dataset.make_one_shot_iterator().get_next()
+    values = []
+    while True:
+        try:
+            values.append(tf_sess.run(get_next_tensor))
+        except tf.errors.OutOfRangeError:
+            break
+    assert len(values) == 3

--- a/tf_align_model_input_feature_percentiles.ipynb
+++ b/tf_align_model_input_feature_percentiles.ipynb
@@ -19,6 +19,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "NUM_LCS = 10_000  # key parameter, turn it down if you want this notebook to finish faster.\n",
+    "\n",
+    "# Settings determining type of features extracted.\n",
+    "window_size = 10\n",
+    "band_time_diff = 4.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from matplotlib import pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -40,7 +53,7 @@
    "source": [
     "%%time\n",
     "import random\n",
-    "sample_ids = random.Random(828372).sample(list(all_ids), 10_000)\n",
+    "sample_ids = random.Random(828372).sample(list(all_ids), NUM_LCS)\n",
     "\n",
     "lcs = []\n",
     "_chunk_sz = 100\n",
@@ -67,9 +80,7 @@
     "from justice.features import per_point_dataset\n",
     "from justice.features import raw_value_features\n",
     "\n",
-    "window_size = 10\n",
     "batch_size = 32\n",
-    "band_time_diff = 4.0\n",
     "rve = raw_value_features.RawValueExtractor(\n",
     "    window_size=window_size,\n",
     "    band_settings=band_settings_params.BandSettings(lcs[0].expected_bands)\n",


### PR DESCRIPTION
This starts logic for generating positive examples for the alignment model. We take an existing light curve, duplicate it (so now we have both "sides", `lca` and `lcb`), and then mutate one or both sides by linear transformations and subsampling. I filed 2 issues for potentially making this better. An advanced idea would be to try and use a GAN to distinguish between synthetic positives and real data, and downweight/filter out unrealistic synthetic data.