### PR TITLE
Fix visualize notebook (and change to bcolz)

### DIFF
--- a/Visualize_data.ipynb
+++ b/Visualize_data.ipynb
@@ -30,8 +30,9 @@
     "from justice.datasets import plasticc_data\n",
     "from justice import visualize\n",
     "from justice.features import period_distribution\n",
-    "training = plasticc_data.PlasticcDataset.training_data()\n",
-    "lcs = plasticc_data.PlasticcDatasetLC.get_lcs_by_target(\"data/plasticc_training_data.db\",53, ddf=True)"
+    "\n",
+    "source = plasticc_data.PlasticcBcolzSource.get_default()\n",
+    "lcs = plasticc_data.PlasticcDatasetLC.get_lcs_by_target(source, 53)"
    ]
   },
   {
@@ -53,10 +54,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
-    "period_best = mbp.best_period\n",
+    "period_best = mbp.best_periods[np.argmax(mbp.scores)]\n",
     "print(period_best)\n",
     "folded = lc.bands['r'].time % period_best\n",
     "print (folded)"
@@ -97,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I was just showing a friend this project & couldn't run the visualize notebook since I don't have the sqlite ... since I think bcolz is basically required at this point I switched to that. Also mbp.best_period doesn't exist, just mbp.best_periods.